### PR TITLE
Check For Python 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@
 /cmake-build-debug
 /psrc/makes
 /psrc/__pycache__
+/psrc/Makefile
+/psrc/Makefile.in
+/ptest/Makefile
+/ptest/Makefile.in
+test-driver

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,7 @@ AM_CONDITIONAL(BUILD_FORTRAN, [test "x$enable_fortran" = xyes])
 
 # Does the user want to enable Python library?
 AC_MSG_CHECKING([whether Python library should be built])
+AM_PATH_PYTHON([3.0])
 AC_ARG_ENABLE([python],
               [AS_HELP_STRING([--enable-python],
                               [build the ncglm Python library.])])

--- a/configure.ac
+++ b/configure.ac
@@ -56,7 +56,9 @@ AC_ARG_ENABLE([python],
                               [build the ncglm Python library.])])
 test "x$enable_python" = xyes || enable_python=no
 AC_MSG_RESULT([$enable_python])
-AM_PATH_PYTHON([3.0])
+if test "x$enable_python" = xyes; then
+    AM_PATH_PYTHON([3.0])
+fi
 AM_CONDITIONAL(BUILD_PYTHON, [test "x$enable_python" = xyes])
 
 # Does the user want to build documentation?

--- a/configure.ac
+++ b/configure.ac
@@ -51,12 +51,12 @@ AM_CONDITIONAL(BUILD_FORTRAN, [test "x$enable_fortran" = xyes])
 
 # Does the user want to enable Python library?
 AC_MSG_CHECKING([whether Python library should be built])
-AM_PATH_PYTHON([3.0])
 AC_ARG_ENABLE([python],
               [AS_HELP_STRING([--enable-python],
                               [build the ncglm Python library.])])
 test "x$enable_python" = xyes || enable_python=no
 AC_MSG_RESULT([$enable_python])
+AM_PATH_PYTHON([3.0])
 AM_CONDITIONAL(BUILD_PYTHON, [test "x$enable_python" = xyes])
 
 # Does the user want to build documentation?

--- a/psrc/nclgm.py.in
+++ b/psrc/nclgm.py.in
@@ -5,18 +5,9 @@
 import ctypes
 import os
 
-# Full path is necessiary for cytpes function.
-temp = os.path.abspath(__file__)
-temp = os.path.realpath(temp)
-temp = os.path.dirname(temp)
-end = len(temp) - 4
-path = temp[:end] + "src"
-lib = os.path.join(path, "libncglm.so")
-
-# Checks that path is correct. Will also be removed later.
-path = "\nPath: \n" + lib + "\n"
-
 # Creating Libraries
+lib = "path"
+
 try:
     lib_ncglm = ctypes.CDLL(lib)
 except Exception as err:
@@ -24,10 +15,11 @@ except Exception as err:
     print(err)
     exit()
 
+
 # Specifying Functions
 read_group_vars = lib_ncglm.read_group_vars
 glm_read_group_structs = lib_ncglm.glm_read_group_structs
-glm_read_group_arrays = lib_ncglm.glm_read_group_arrays
+glm_read_group_arrays = lib_ncglm.glm_read_group_arraysP
 
 read_event_vars = lib_ncglm.read_event_vars
 glm_read_event_structs = lib_ncglm.glm_read_event_structs
@@ -44,4 +36,3 @@ glm_read_file_arrays = lib_ncglm.glm_read_file_arrays
 
 # Specify inputs
 # read_group_vars.argtypes = [ctypes.c_int, ctypes.]
-

--- a/ptest/ptst.py
+++ b/ptest/ptst.py
@@ -10,7 +10,7 @@ NUM_VAL = 5
 
 
 def main():
-    print("Testing Python Wrapper\n")
+    print("TestingPythonWrapper\n")
     print("Testing GLM event reads.")
     glm_event()
 
@@ -40,4 +40,7 @@ def fabs(equation):
 
 
 def print_time(offset):
-    print(time.asctime(time.localtime(time.time()+offset)))
+    print(time.asctime(time.localtime(time.time() + offset)))
+
+
+main()


### PR DESCRIPTION
We now check for python in configure.ac unless --disable-python is used
Fixed #31 

It also requires at least python 3.0 which the wrapper needs. At the moment, if --disable-python is not used and the user does not have at least python 3, then configure.ac will be aborted. 